### PR TITLE
 spring boot support added. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ public class PlaySpringDIConfiguration {
 }
 ```
 
+### For Spring Boot support (Optional)
+
+In order to support Spring Boot auto configurations, you can define additional context. This boot context is set as the parent context to the above play context. 
+
+In play dev mode, this context is reused during application reload in order to save time.
+
+```sh
+play.spring.boot.configs = ["com.example.PlaySpringBootConfiguration"]
+
+```
+
 ## Migrating from Guice
 
 If you want to migrate your existing project from `guice` you should follow these steps

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayLibrary)
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % PlayVersion,
   "org.springframework" % "spring-context" % SpringVersion,
+  "org.springframework.boot" % "spring-boot" % "1.4.7.RELEASE",
+
 
   "com.typesafe.play" %% "play-java" % PlayVersion,
   "com.novocode" % "junit-interface" % "0.11" % "test"

--- a/src/main/scala/com/lightbend/play/spring/SpringInjector.scala
+++ b/src/main/scala/com/lightbend/play/spring/SpringInjector.scala
@@ -17,16 +17,16 @@
 package com.lightbend.play.spring
 
 import org.springframework.beans.BeanInstantiationException
-import org.springframework.beans.factory.config.{ AutowireCapableBeanFactory, BeanDefinition }
+import org.springframework.beans.factory.config.{ AutowireCapableBeanFactory, BeanDefinition, ConfigurableListableBeanFactory }
 import org.springframework.beans.factory.{ BeanCreationException, NoSuchBeanDefinitionException }
 import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor
-import org.springframework.beans.factory.support.{ GenericBeanDefinition, DefaultListableBeanFactory }
-import play.api.inject.{ BindingKey, Injector, Modules, Module }
-import play.api.{ PlayException, Configuration, Environment }
+import org.springframework.beans.factory.support.{ DefaultListableBeanFactory, GenericBeanDefinition }
+import play.api.inject.{ BindingKey, Injector, Module, Modules }
+import play.api.{ Configuration, Environment, PlayException }
 
 import scala.reflect.ClassTag
 
-class SpringInjector(factory: DefaultListableBeanFactory) extends Injector {
+class SpringInjector(var factory: DefaultListableBeanFactory) extends Injector {
 
   private val bpp = new AutowiredAnnotationBeanPostProcessor()
   bpp.setBeanFactory(factory)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.3-SNAPSHOT"
+version in ThisBuild := "0.0.3"


### PR DESCRIPTION
In order to support Spring Boot auto configurations, you can define additional context. This boot context is set as the parent context to the above play context. 
In play dev mode, this context is reused during application reload in order to save time.

play.spring.boot.configs = ["com.example.PlaySpringBootConfiguration"]