### PR TITLE
Build with OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
 - 2.12.4
 - 2.11.11
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - sbt ++$TRAVIS_SCALA_VERSION validateCode test
 cache:


### PR DESCRIPTION
Oracle JDK 8 is no longer available on Travis CI.